### PR TITLE
fix(checkstyle): replace removed JavadocStyle check with SummaryJavadoc

### DIFF
--- a/conf/checkstyle.xml
+++ b/conf/checkstyle.xml
@@ -91,7 +91,7 @@
         <module name="JavadocMethod"/>
         <module name="JavadocType"/>
         <module name="JavadocVariable"/>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
         <module name="MissingJavadocMethod"/>
 
         <!-- Checks for Naming Conventions.                  -->

--- a/src/main/java/com/github/aistomin/maven/dependencies/analyser/MdaMojo.java
+++ b/src/main/java/com/github/aistomin/maven/dependencies/analyser/MdaMojo.java
@@ -55,7 +55,7 @@ public final class MdaMojo extends AbstractMojo {
     private FailureLevel level;
 
     /**
-     * Is validation enabled?
+     * Whether the validation is enabled.
      */
     @Parameter(property = "enabled", defaultValue = "true")
     private Boolean enabled;


### PR DESCRIPTION
Checkstyle 13.9.0 removes the JavadocStyle check ("Remove JavadocStyle check, use SummaryJavadoc Check instead"), so conf/checkstyle.xml can no longer be loaded once the dependency is bumped:

    cannot initialize module TreeWalker
      - cannot initialize module JavadocStyle

That is a configuration error rather than a style violation, and the maven-checkstyle-plugin runs with failsOnError=true at the verify phase, so the whole build fails. This is what turns #498 (checkstyle 13.8.0 -> 13.9.0) red.

Follow the upstream migration advice and switch to SummaryJavadoc. It is slightly stricter about the sentence terminator, which flagged a single field javadoc in MdaMojo; reword it to end with a period.

SummaryJavadoc already exists in 13.8.0, so this change is green both before and after the dependency bump.